### PR TITLE
Fix onClick is not a function for Text

### DIFF
--- a/src/components/layout/Text.tsx
+++ b/src/components/layout/Text.tsx
@@ -133,7 +133,7 @@ export default function Text({ text = '', color, variant = 'old_normal', onClick
           : styles.mention,
       ])}
       role="button"
-      onClick={() => onClick(text)}
+      onClick={onClick && (() => onClick(textsssss))}
     >
       {text}
       {children}


### PR DESCRIPTION
- Fix bug where click on a `Text` component that didn't have `onClick` set would throw an error