### PR TITLE
Add horizontal margin to modal

### DIFF
--- a/src/components/layout/ModalBase.tsx
+++ b/src/components/layout/ModalBase.tsx
@@ -118,7 +118,7 @@ const styles = StyleSheet.create({
     overflowY: 'hidden',
     overflowX: 'auto',
     borderRadius: '5px',
-    margin: '0 auto',
+    margin: '0 8px',
     position: 'relative',
     backgroundColor: 'var(--background-primary)',
     display: 'flex',


### PR DESCRIPTION
- Add horizontal padding to the modal so it is not against the edge of the screen on mobile

![image](https://user-images.githubusercontent.com/25378294/137832944-6ed63df1-b5c8-41af-869f-68d0a63b049e.png)

Closes #21 