### PR TITLE
Fix Button padding. Allow children on Button

### DIFF
--- a/__tests__/Button.test.tsx
+++ b/__tests__/Button.test.tsx
@@ -29,4 +29,9 @@ describe('<Button />', () => {
 
     expect(screen.getByRole('button')).toBeDisabled();
   });
+  it('should render the children', () => {
+    render(<Button>Children</Button>);
+
+    expect(screen.getByText(/children/i)).toBeInTheDocument();
+  });
 });

--- a/src/components/inputs/Button.tsx
+++ b/src/components/inputs/Button.tsx
@@ -1,18 +1,20 @@
-import React, { MouseEvent } from 'react';
+import React, { MouseEvent, ReactChild } from 'react';
 import { StyleSheet, css, CSSProperties } from 'aphrodite';
 import { Button as ReakitButton } from 'reakit/Button';
 import { PulseLoader } from 'react-spinners';
 
 type ButtonTypes = 'blurple' | 'greyple' | 'green' | 'red_filled' | 'red_empty' | 'white_empty' | 'only_text';
 interface ButtonProps {
-  text: string;
-  onClick(event: MouseEvent<HTMLButtonElement>): void;
+  text?: string;
+  onClick?(event: MouseEvent<HTMLButtonElement>): void;
   type?: ButtonTypes;
   disabled?: boolean;
   loading?: boolean;
   size?: 'small' | 'normal' | 'large' | 'full' | 'custom';
   width?: string | number;
   height?: string | number;
+  childrenPosition?: 'left' | 'right';
+  children?: ReactChild;
 }
 
 const baseNormalStyle: CSSProperties = {
@@ -33,7 +35,7 @@ const styles = StyleSheet.create({
     borderRadius: '3px',
     fontSize: '14px',
     fontWeight: 500,
-    padding: '2px 16',
+    padding: '2px 16px',
     outline: 0,
     cursor: 'pointer',
     display: 'flex',
@@ -49,6 +51,12 @@ const styles = StyleSheet.create({
       cursor: 'not-allowed',
       opacity: 0.5,
     },
+  },
+  childrenLeft: {
+    flexDirection: 'row-reverse',
+  },
+  childrenRight: {
+    flexDirection: 'row',
   },
   blurple: {
     ...baseNormalStyle,
@@ -127,6 +135,8 @@ export default function Button({
   size = 'normal',
   width = 'auto',
   height = 'auto',
+  childrenPosition = 'left',
+  children,
 }: ButtonProps) {
   const style =
     size === 'small'
@@ -168,12 +178,23 @@ export default function Button({
 
   return (
     <ReakitButton
-      onClick={onClick}
+      onClick={(event) => onClick && onClick(event)}
       disabled={disabled || loading}
-      className={css([styles.buttonBase, buttonType])}
+      className={css([
+        styles.buttonBase,
+        buttonType,
+        childrenPosition === 'left' ? styles.childrenLeft : styles.childrenRight,
+      ])}
       style={style}
     >
-      {loading ? <PulseLoader loading={loading} color={type === 'red_empty' ? '#f04747' : 'white'} size={8} /> : text}
+      {loading ? (
+        <PulseLoader loading={loading} color={type === 'red_empty' ? '#f04747' : 'white'} size={8} />
+      ) : (
+        <>
+          <span>{text && text}</span>
+          <span>{children && children}</span>
+        </>
+      )}
     </ReakitButton>
   );
 }

--- a/src/components/layout/Text.tsx
+++ b/src/components/layout/Text.tsx
@@ -133,7 +133,7 @@ export default function Text({ text = '', color, variant = 'old_normal', onClick
           : styles.mention,
       ])}
       role="button"
-      onClick={onClick && (() => onClick(textsssss))}
+      onClick={onClick && (() => onClick(text))}
     >
       {text}
       {children}

--- a/stories/inputs/Button.stories.tsx
+++ b/stories/inputs/Button.stories.tsx
@@ -70,6 +70,14 @@ export default {
         type: 'text',
       },
     },
+    childrenPosition: {
+      defaultValue: 'left',
+      description: 'The side of the button the children will be on.',
+      control: {
+        type: 'inline-radio',
+        options: ['left', 'right'],
+      },
+    },
   },
 } as Meta;
 
@@ -105,6 +113,34 @@ export const Loading: Story<ButtonProps & DiscordProviderProps> = (props) => {
   return (
     <DiscordProvider newMarketingColors={newMarketingColors}>
       <Button {...props} onClick={click} loading />
+    </DiscordProvider>
+  );
+};
+
+export const Children: Story<ButtonProps & DiscordProviderProps> = (props) => {
+  const { newMarketingColors } = props;
+
+  const click = () => console.log('Button click');
+
+  return (
+    <DiscordProvider newMarketingColors={newMarketingColors}>
+      <Button {...props} text={null} onClick={click}>
+        Children
+      </Button>
+    </DiscordProvider>
+  );
+};
+
+export const TextAndChildren: Story<ButtonProps & DiscordProviderProps> = (props) => {
+  const { newMarketingColors } = props;
+
+  const click = () => console.log('Button click');
+
+  return (
+    <DiscordProvider newMarketingColors={newMarketingColors}>
+      <Button {...props} onClick={click}>
+        Children
+      </Button>
     </DiscordProvider>
   );
 };


### PR DESCRIPTION
- Fix `Button` horizontal padding not being set properly
- Make `text` and `onClick` props on `Button` optional
- Allow children on `Button`
- Add `childrenPosition` prop to `Button`
- Fix typo in the `Text` component that was causing unit tests to fail

Closes #19
Closes #14 