### PR TITLE
Modal alwaysCloseOnButtonPress

### DIFF
--- a/__tests__/Modal.test.tsx
+++ b/__tests__/Modal.test.tsx
@@ -119,4 +119,102 @@ describe('<Modal />', () => {
 
     expect(mockCancelClick).toHaveBeenCalledTimes(1);
   });
+  it('should not hide the modal when alwaysCloseOnButtonPress is false and the submit button is clicked', () => {
+    const mockSetVisible = jest.fn();
+
+    render(
+      <ThemeContext.Provider value={{ theme: 'dark', newMarketingColors: true, setTheme: jest.fn() }}>
+        <Modal
+          visible
+          setVisible={mockSetVisible}
+          title="Title"
+          onSubmitClick={jest.fn()}
+          alwaysCloseOnButtonPress={false}
+          submitText="Submit"
+          cancelText="Cancel"
+          onCancelClick={mockCancelClick}
+        >
+          Modal Contents
+        </Modal>
+      </ThemeContext.Provider>
+    );
+
+    expect(mockSetVisible).toHaveBeenCalledTimes(0);
+    userEvent.click(screen.getByText(/submit/i));
+
+    expect(mockSetVisible).toHaveBeenCalledTimes(0);
+  });
+  it('should not hide the modal when alwaysCloseOnButtonPress is false and the cancel button is clicked', () => {
+    const mockSetVisible = jest.fn();
+
+    render(
+      <ThemeContext.Provider value={{ theme: 'dark', newMarketingColors: true, setTheme: jest.fn() }}>
+        <Modal
+          visible
+          setVisible={mockSetVisible}
+          title="Title"
+          onSubmitClick={jest.fn()}
+          alwaysCloseOnButtonPress={false}
+          submitText="Submit"
+          cancelText="Cancel"
+          onCancelClick={mockCancelClick}
+        >
+          Modal Contents
+        </Modal>
+      </ThemeContext.Provider>
+    );
+
+    expect(mockSetVisible).toHaveBeenCalledTimes(0);
+    userEvent.click(screen.getByText(/cancel/i));
+
+    expect(mockSetVisible).toHaveBeenCalledTimes(0);
+  });
+  it('should hide the modal when alwaysCloseOnButtonPress is false and the submit button is clicked', () => {
+    const mockSetVisible = jest.fn();
+
+    render(
+      <ThemeContext.Provider value={{ theme: 'dark', newMarketingColors: true, setTheme: jest.fn() }}>
+        <Modal
+          visible
+          setVisible={mockSetVisible}
+          title="Title"
+          onSubmitClick={jest.fn()}
+          submitText="Submit"
+          cancelText="Cancel"
+          onCancelClick={mockCancelClick}
+        >
+          Modal Contents
+        </Modal>
+      </ThemeContext.Provider>
+    );
+
+    expect(mockSetVisible).toHaveBeenCalledTimes(0);
+    userEvent.click(screen.getByText(/submit/i));
+
+    expect(mockSetVisible).toHaveBeenCalledTimes(1);
+  });
+  it('should hide the modal when alwaysCloseOnButtonPress is false and the cancel button is clicked', () => {
+    const mockSetVisible = jest.fn();
+
+    render(
+      <ThemeContext.Provider value={{ theme: 'dark', newMarketingColors: true, setTheme: jest.fn() }}>
+        <Modal
+          visible
+          setVisible={mockSetVisible}
+          title="Title"
+          onSubmitClick={jest.fn()}
+          submitText="Submit"
+          cancelText="Cancel"
+          onCancelClick={mockCancelClick}
+        >
+          Modal Contents
+        </Modal>
+      </ThemeContext.Provider>
+    );
+
+    expect(mockSetVisible).toHaveBeenCalledTimes(0);
+    userEvent.click(screen.getByText(/cancel/i));
+
+    expect(mockSetVisible).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/layout/Modal.tsx
+++ b/src/components/layout/Modal.tsx
@@ -12,6 +12,7 @@ interface ModalProps {
   title: string;
   children: ReactNode;
   onSubmitClick(event: MouseEvent<HTMLButtonElement>): void;
+  alwaysCloseOnButtonPress?: boolean;
   closeOnEscapeKeyPress?: boolean;
   onEscapeKeyPress?(event: KeyboardEvent): void;
   submitText?: string;
@@ -69,11 +70,12 @@ export default function Modal({
   visible,
   setVisible,
   title,
-  submitText = 'Ok',
   children,
   onSubmitClick,
+  alwaysCloseOnButtonPress = true,
   closeOnEscapeKeyPress = true,
   onEscapeKeyPress,
+  submitText = 'Ok',
   submitColor = 'blurple',
   submitButtonFull = false,
   submitButtonLoading = false,
@@ -82,6 +84,21 @@ export default function Modal({
   onCancelClick,
 }: ModalProps) {
   const { newMarketingColors } = useThemeContext();
+
+  const handleSubmit = (event: MouseEvent<HTMLButtonElement>) => {
+    onSubmitClick(event);
+    if (alwaysCloseOnButtonPress) {
+      setVisible(false);
+    }
+  };
+  const handleClose = (event: MouseEvent<HTMLButtonElement>) => {
+    if (onCancelClick) {
+      onCancelClick(event);
+    }
+    if (alwaysCloseOnButtonPress) {
+      setVisible(false);
+    }
+  };
 
   return (
     <ModalBase
@@ -102,23 +119,10 @@ export default function Modal({
             text={submitText}
             loading={submitButtonLoading}
             disabled={submitButtonDisabled}
-            onClick={(event) => {
-              onSubmitClick(event);
-              setVisible(false);
-            }}
+            onClick={handleSubmit}
           />
           {cancelText && cancelText.length > 0 && (
-            <Button
-              type="only_text"
-              size="normal"
-              text={cancelText}
-              onClick={(event) => {
-                if (onCancelClick) {
-                  onCancelClick(event);
-                }
-                setVisible(false);
-              }}
-            />
+            <Button type="only_text" size="normal" text={cancelText} onClick={handleClose} />
           )}
         </div>
       </div>

--- a/stories/layout/Modal.stories.tsx
+++ b/stories/layout/Modal.stories.tsx
@@ -30,9 +30,23 @@ export default {
     },
     title: {
       defaultValue: 'Title',
-      description: 'The title of the modal',
+      description: 'The title of the modal.',
       control: {
         type: 'text',
+      },
+    },
+    alwaysCloseOnButtonPress: {
+      defaultValue: true,
+      description: 'Should the modal automatically close when the cancel or submit button is clicked.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    closeOnEscapeKeyPress: {
+      defaultValue: true,
+      description: 'Should the modal automatically close when the escape key is pressed.',
+      control: {
+        type: 'boolean',
       },
     },
     submitText: {
@@ -42,33 +56,33 @@ export default {
         type: 'text',
       },
     },
-    submitButtonFull: {
-      defaultValue: false,
-      description: 'If the width of the submit button should 100%',
-      control: {
-        type: 'boolean',
-      },
-    },
-    submitButtonLoading: {
-      defaultValue: false,
-      description: 'If the submit button is loading',
-      control: {
-        type: 'boolean',
-      },
-    },
-    submitButtonDisabled: {
-      defaultValue: false,
-      description: 'If the submit button is disabled',
-      control: {
-        type: 'boolean',
-      },
-    },
     submitColor: {
       defaultValue: 'blurple',
       description: 'The color of the submit button.',
       control: {
         type: 'inline-radio',
         values: ['blurple', 'green', 'red'],
+      },
+    },
+    submitButtonFull: {
+      defaultValue: false,
+      description: 'If the width of the submit button should 100%.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    submitButtonLoading: {
+      defaultValue: false,
+      description: 'If the submit button is loading.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    submitButtonDisabled: {
+      defaultValue: false,
+      description: 'If the submit button is disabled.',
+      control: {
+        type: 'boolean',
       },
     },
     cancelText: {


### PR DESCRIPTION
- Add `alwaysCloseOnButtonPress` on `Modal` component to say if the modal should automatically call `setVisible` with `false` when the cancel or submit button is pressed. If this is set to false, the users will have to manually call their `setVisible` function with `false` when they want to close it. This could be useful for scenarios where form validation occurs in the modal when the submit button is pressed.